### PR TITLE
Revert sriov.c back to dpdk 2.2.

### DIFF
--- a/README
+++ b/README
@@ -5,5 +5,3 @@ the standard ixgbe driver.
 
 The directories here contain the VFD code and some system tools such as the iplex 
 command line interface tool which is used to interact with the daemon. 
-
-(Requires dpdk version 16.04)


### PR DESCRIPTION
The changes in commit b6c43e06b6c527368271a04e680780d25a438149 placed
the dpdk_1604 changes back in. Grrrr.
This reverts the sriov.c back to 2.2 code, and removes the note in the
main readme that indicates it's 1604 only.