### PR TITLE
Drop enable and HW crc strip default changes

### DIFF
--- a/doc/master.mk
+++ b/doc/master.mk
@@ -1,0 +1,24 @@
+# master makefile for inclusion
+
+%.eps: %.fig
+    fig2dev -L eps ${prereq} ${target}
+
+%.png: %.fig
+    fig2dev -L png ${prereq} ${target}
+
+
+%_slides :  %_slides.xfm
+	pfm -g 8ix11i ${prereq%% *} $target.ps
+
+%.ps :  %.xfm
+	pfm ${prereq%% *} $target 
+
+%.html :  %.xfm
+	hfm ${prereq%% *} $target 
+
+%.pdf : %.ps
+	gs -I/usr/local/share/ghostscript/fonts -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -sOutputFile=$target ${prereq% *}
+
+%.txt : %.xfm
+	tfm ${prereq%% *} $target 
+

--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -17,7 +17,7 @@ binaries = jwrapper_test parm_file_test list_test fifo_test bleat_test
 all: libvfd.a
 
 lib = libvfd.a
-lib_src = jwrapper symtab config ng_flowmgr fifo list_files bleat hot_plug
+lib_src = jwrapper jw_xapi symtab config ng_flowmgr fifo list_files bleat hot_plug
 $(lib): $(lib_src:=.o)
 	ar r $(lib) $^
 

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -13,6 +13,7 @@
 				16 Jun 2016 : Add option to allow loop-back.
 				18 Oct 2016 : Add chenges to support new QoS entries.
 				29 Nov 2016 : Added changes to support queue share in vf config.
+				11 Feb 2017 : Fix issues with leading spaces rather than tabs (formatting)
 */
 
 #include <fcntl.h>
@@ -152,10 +153,10 @@ extern parms_t* read_parms( char* fname ) {
 	char		sm_wrk[128];	// small work buffer
 	int			i, j, k;
 	int			def_mtu;		// default mtu (pulled and used to set pciid struct, but not kept in parms
-	tc_class_t* tc_class_ptr;    // ponter to heap location
-    int         priority;       // hold priority read from tclasses object
-    void*       tcobj;
-    void*       bwgrpobj;
+	tc_class_t* tc_class_ptr;	// ponter to heap location
+	int		 priority;	   // hold priority read from tclasses object
+	void*	   tcobj;
+	void*	   bwgrpobj;
 
 	if( (buf = file_into_buf( fname, NULL )) == NULL ) {
 		return NULL;
@@ -253,84 +254,84 @@ extern parms_t* read_parms( char* fname ) {
 							parms->pciids[i].id = ltrim( stuff );
 
 							parms->pciids[i].mtu = !jw_is_value( pobj, "mtu" ) ? def_mtu : (int) jw_value( pobj, "mtu" );
-							if( !jw_is_bool( pobj, "enable_loopback" ) ? 0 : (int) jw_value( pobj, "enable_loopback" ) ) {		// default to false if not there
-								parms->pciids[i].flags |= PFF_LOOP_BACK;
+							if( !jw_is_bool( pobj, "enable_loopback" ) ? 0 : (int) jw_value( pobj, "enable_loopback" ) ) {		
+								parms->pciids[i].flags |= PFF_LOOP_BACK; 			// default to false if not there
 							} else {
 								parms->pciids[i].flags &= ~PFF_LOOP_BACK;			// disable if set to false
 							}
-							if( !jw_is_bool( pobj, "vf_oversubscription" ) ? 0 : (int) jw_value( pobj,  "vf_oversubscription" ) ) {    // default to false if not there
-                                parms->pciids[i].flags |= PFF_VF_OVERSUB;
-                            } else {
-                                parms->pciids[i].flags &= ~PFF_VF_OVERSUB;          // disable if set to false
-                            }
-                            
-                            parms->pciids[i].ntcs = 4;																// default to 4 and we will up to 8 if we see pri > 3
-                            if( (jntcs = jw_array_len( pobj, "tclasses" )) > 0 ) {					  				// number of tcs supplied in the json
-                                //fprintf( stderr, "parsing tclasses = %d\n", parms->pciids[i].ntcs);  // **Debugging purpose only
-                                if( (tc_class_ptr = (tc_class_t*) malloc (sizeof(tc_class_t) * MAX_TCS)) == NULL ) {	// allways allocate a full set
+							if( !jw_is_bool( pobj, "vf_oversubscription" ) ? 0 : (int) jw_value( pobj,  "vf_oversubscription" ) ) {	
+								parms->pciids[i].flags |= PFF_VF_OVERSUB; 			// default to false if not there
+							} else {
+								parms->pciids[i].flags &= ~PFF_VF_OVERSUB;		  // disable if set to false
+							}
+							
+							parms->pciids[i].ntcs = 4;							// default to 4 and we will up to 8 if we see pri > 3
+							if( (jntcs = jw_array_len( pobj, "tclasses" )) > 0 ) {					  				// number of tcs supplied in the json
+								//fprintf( stderr, "parsing tclasses = %d\n", parms->pciids[i].ntcs);  // **Debugging purpose only
+								if( (tc_class_ptr = (tc_class_t*) malloc (sizeof(tc_class_t) * MAX_TCS)) == NULL ) {	// allways allocate a full set
 									errno = ENOMEM;
 									jw_nuke( jblob );
 									free_parms( parms );
 									return NULL;
 								}
-                                memset( tc_class_ptr, 0, sizeof(tc_class_t) * MAX_TCS );
-								parms->pciids[i].tcs[0] = tc_class_ptr;									// dont chance that pri == 0 is always there; this ensures us a ptr to free
+								memset( tc_class_ptr, 0, sizeof(tc_class_t) * MAX_TCS );
+								parms->pciids[i].tcs[0] = tc_class_ptr;			// dont chance that pri == 0 is always there; this ensures us a ptr to free
 
-                                for( j = 0; j < jntcs; j++ ) {
-                                    if( (tcobj = jw_obj_ele( pobj, "tclasses", j )) != NULL ) {					// pull out the next element
-                                        priority = (int) jw_value( tcobj, "pri" );
+								for( j = 0; j < jntcs; j++ ) {
+									if( (tcobj = jw_obj_ele( pobj, "tclasses", j )) != NULL ) {					// pull out the next element
+										priority = (int) jw_value( tcobj, "pri" );
 										if( priority < 0 || priority >= MAX_TCS ) {								// don't allow priority out of range
 											continue;
 										}
 
 										if( priority > 3 ) {
-                            				parms->pciids[i].ntcs = 8;
+											parms->pciids[i].ntcs = 8;
 										}
 
-                                        parms->pciids[i].tcs[priority] = tc_class_ptr + priority;				// use priority as index into the block allocated
+										parms->pciids[i].tcs[priority] = tc_class_ptr + priority;			// use priority as index into the block allocated
 
-                                        if( (stuff = jw_string( tcobj, "name" )) == NULL ) {
+										if( (stuff = jw_string( tcobj, "name" )) == NULL ) {
 											snprintf( sm_wrk, sizeof( sm_wrk ), "TC-%d", priority );
-                                            stuff = sm_wrk;
-                                        } 
+											stuff = sm_wrk;
+										} 
 										parms->pciids[i].tcs[priority]->hr_name = ltrim( stuff );
 
-                                        if( !jw_is_bool( tcobj, "llatency" ) ? 0 : (int) jw_value( tcobj, "llatency" ) ) {
-                                            parms->pciids[i].tcs[priority]->flags |= TCF_LOW_LATENCY;
-                                        } else {
-                                            parms->pciids[i].tcs[priority]->flags &= ~TCF_LOW_LATENCY;
-                                        }
-                                        if( !jw_is_bool( tcobj, "lsp" ) ? 0 : (int) jw_value( tcobj, "lsp" ) ) {
-                                            parms->pciids[i].tcs[priority]->flags |= TCF_BW_STRICTP;
-                                        } else {
-                                            parms->pciids[i].tcs[priority]->flags &= ~TCF_BW_STRICTP;
-                                        }
-                                        if( !jw_is_bool( tcobj, "bsp" ) ? 0 : (int) jw_value( tcobj, "bsp" ) ) {
-                                            parms->pciids[i].tcs[priority]->flags |= TCF_LNK_STRICTP;
-                                        } else {
-                                            parms->pciids[i].tcs[priority]->flags &= ~TCF_LNK_STRICTP;
-                                        }
-                                        parms->pciids[i].tcs[priority]->max_bw = !jw_is_value( tcobj, "max_bw" ) ? 100 : IBOUND( (int)jw_value( tcobj, "max_bw" ), 1, 100 );
-                                        parms->pciids[i].tcs[priority]->min_bw = !jw_is_value( tcobj, "min_bw" ) ? 1 : IBOUND( (int)jw_value( tcobj, "min_bw" ), 1, 100 );
-                                    } else {
+										if( !jw_is_bool( tcobj, "llatency" ) ? 0 : (int) jw_value( tcobj, "llatency" ) ) {
+											parms->pciids[i].tcs[priority]->flags |= TCF_LOW_LATENCY;
+										} else {
+											parms->pciids[i].tcs[priority]->flags &= ~TCF_LOW_LATENCY;
+										}
+										if( !jw_is_bool( tcobj, "lsp" ) ? 0 : (int) jw_value( tcobj, "lsp" ) ) {
+											parms->pciids[i].tcs[priority]->flags |= TCF_BW_STRICTP;
+										} else {
+											parms->pciids[i].tcs[priority]->flags &= ~TCF_BW_STRICTP;
+										}
+										if( !jw_is_bool( tcobj, "bsp" ) ? 0 : (int) jw_value( tcobj, "bsp" ) ) {
+											parms->pciids[i].tcs[priority]->flags |= TCF_LNK_STRICTP;
+										} else {
+											parms->pciids[i].tcs[priority]->flags &= ~TCF_LNK_STRICTP;
+										}
+										parms->pciids[i].tcs[priority]->max_bw = !jw_is_value( tcobj, "max_bw" ) ? 100 : IBOUND( (int)jw_value( tcobj, "max_bw" ), 1, 100 );
+										parms->pciids[i].tcs[priority]->min_bw = !jw_is_value( tcobj, "min_bw" ) ? 1 : IBOUND( (int)jw_value( tcobj, "min_bw" ), 1, 100 );
+									} else {
 										fprintf( stderr, "internal mishap parsing tclasses from config file j=%d expected=%d\n", j, parms->pciids[i].ntcs );
 										jw_nuke( jblob );
 										free_parms( parms );
 										return NULL;
-                                    }
-                                }
+									}
+								}
 
-                            }
-                            if (( bwgrpobj = jw_blob( pobj, "bw_grps" )) != NULL) {
-                                for ( j = 0; j < sizeof(parms->pciids[i].bw_grps)/sizeof(bw_grp_t); j++ ) {
-                                    sprintf(stuff, "bwg%d", j);
-                                    if( jw_exists(bwgrpobj, stuff) && (parms->pciids[i].bw_grps[j].ntcs  = jw_array_len( bwgrpobj, stuff )) > 0 ) {
-                                        for( k = 0; k < parms->pciids[i].bw_grps[j].ntcs; k++ ) {
-                                            parms->pciids[i].bw_grps[j].tcs[k] = (int) jw_value_ele( bwgrpobj, stuff, k );
-                                        }
-                                    }
-                                }
-                            }
+							}
+							if (( bwgrpobj = jw_blob( pobj, "bw_grps" )) != NULL) {
+								for ( j = 0; j < sizeof(parms->pciids[i].bw_grps)/sizeof(bw_grp_t); j++ ) {
+									sprintf(stuff, "bwg%d", j);
+									if( jw_exists(bwgrpobj, stuff) && (parms->pciids[i].bw_grps[j].ntcs  = jw_array_len( bwgrpobj, stuff )) > 0 ) {
+										for( k = 0; k < parms->pciids[i].bw_grps[j].ntcs; k++ ) {
+											parms->pciids[i].bw_grps[j].tcs[k] = (int) jw_value_ele( bwgrpobj, stuff, k );
+										}
+									}
+								}
+							}
 						}
 					}
 				}

--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -14,6 +14,8 @@
 				18 Oct 2016 : Add chenges to support new QoS entries.
 				29 Nov 2016 : Added changes to support queue share in vf config.
 				11 Feb 2017 : Fix issues with leading spaces rather than tabs (formatting)
+
+	TODO:		convert things to the new jw_xapi functions to make for easier to read code.
 */
 
 #include <fcntl.h>
@@ -254,6 +256,8 @@ extern parms_t* read_parms( char* fname ) {
 							parms->pciids[i].id = ltrim( stuff );
 
 							parms->pciids[i].mtu = !jw_is_value( pobj, "mtu" ) ? def_mtu : (int) jw_value( pobj, "mtu" );
+							parms->pciids[i].hw_strip_crc = jwx_get_bool( pobj, "hw_strip_crc", 1 );		// strip on by default
+
 							if( !jw_is_bool( pobj, "enable_loopback" ) ? 0 : (int) jw_value( pobj, "enable_loopback" ) ) {		
 								parms->pciids[i].flags |= PFF_LOOP_BACK; 			// default to false if not there
 							} else {

--- a/src/lib/jw_xapi.c
+++ b/src/lib/jw_xapi.c
@@ -1,0 +1,109 @@
+//vi: ts=4 sw=4 noet:
+/*
+	Mnemonic:	jw_xapi.c
+	Abstract:	This is an extended api set for the 'primatives' in jwrapper.
+	Author:		E. Scott Daniels
+	Date:		11 Feb 2017
+
+	Mods:
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <jsmn.h>
+
+#include "vfdlib.h"
+#include "symtab.h"
+
+
+/*
+	Look up a boolean returning the default if it's not a boolean or not defined.
+*/
+extern int jwx_get_bool( void* jblob, char const* field_name, int def_value ) {
+	if( !jw_is_bool( jblob, field_name ) ) { 
+		return def_value;
+	}
+	
+	return jw_value( jblob, field_name );
+}
+
+/*
+	Return the value from the json blob, or the default if it is not a value
+*/
+extern float jwx_get_value( void* jblob, char const* field_name, float def_value ) {
+	if( !jw_is_value( jblob, field_name ) ) { 
+		return def_value;
+	}
+	
+	return jw_value( jblob, field_name );
+}
+
+/*
+	Return the value from the json blob as an integer, or the default if it is not a value
+*/
+extern int jwx_get_ivalue( void* jblob, char const* field_name, int def_value ) {
+	if( !jw_is_value( jblob, field_name ) ) { 
+		return def_value;
+	}
+	
+	return (int) jw_value( jblob, field_name );
+}
+
+/*
+	There are cases where we need a 
+	For cases where a 'value' needs to be used as a string, this will pull the 
+	value from the blob and converts it using the format type passed in. If the 
+	field name is a string in the blob it is returned as is. If the field name 
+	does not exist, the default is returned.
+	Fmt is one of the JWFMT_ constants.
+*/
+extern char* jwx_get_value_as_str( void* jblob, char const* field_name, char const* def_value, int  fmt ) {
+	float	jvalue;				// value from json
+	char	stuff[128];			// should be more than enough :)
+	char*	jstr;				// if represented in json as a string
+
+	if( jw_is_value( jblob, field_name ) ) { 
+		jvalue = jw_value( jblob, field_name );
+		switch( fmt ) {
+			case JWFMT_INT:
+				snprintf( stuff, sizeof( stuff ), "%d", (int) jvalue );
+				break;
+			case JWFMT_FLOAT:
+				snprintf( stuff, sizeof( stuff ), "%f", jvalue );
+
+			case JWFMT_HEX:
+				snprintf( stuff, sizeof( stuff ), "0x%x", (int) jvalue );
+		}
+		return strdup( stuff );
+	}
+
+	if( (jstr = jw_string( jblob, field_name )) ) {		// if already a string, return that
+		return strdup( jstr );
+	}
+
+	if( def_value ) {					// neither way in json, so use default if supplied
+		return strdup( def_value );
+	}
+			
+	return NULL;
+}
+
+/*
+	Looks up field name and returns the value from jblob if its a string.
+	If it's not a string in the json, then the def_value string is duplicated 
+	and returned.
+*/
+extern char* jwx_get_str( void* jblob, char const* field_name, char const* def_value ) {
+	char*	stuff;
+
+	if( (stuff = jw_string( jblob, field_name )) ) {
+		return strdup( stuff );
+	}
+
+	if( def_value ) {
+		return strdup( def_value );
+	}
+
+	return NULL;
+}

--- a/src/lib/jwrapper.c
+++ b/src/lib/jwrapper.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <jsmn.h>
 
+#include "vfdlib.h"
 #include "symtab.h"
 
 #define JSON_SYM_NAME	"_jw_json_string"
@@ -746,4 +747,3 @@ extern int jw_array_len( void* st, const char* name ) {
 
 	return jtp->nele;
 }
-

--- a/src/lib/mkfile
+++ b/src/lib/mkfile
@@ -13,7 +13,7 @@ binaries = jwrapper_test parm_file_test list_test fifo_test bleat_test
 all:V: libvfd.a
 
 lib = libvfd.a
-lib_src = jwrapper symtab config ng_flowmgr fifo list_files bleat hot_plug
+lib_src = jwrapper jw_xapi symtab config ng_flowmgr fifo list_files bleat hot_plug
 $lib(%.o):N:    %.o
 $lib:   ${lib_src:%=$lib(%.o)}
     ksh '(

--- a/src/lib/parm_file_test.c
+++ b/src/lib/parm_file_test.c
@@ -42,6 +42,7 @@ void pprint( parms_t* parms ) {
 	fprintf( stderr, "\tnpciids: %d\n", parms->npciids );
 	for( i = 0; i < parms->npciids; i++ ) {
 		fprintf( stderr, "\tpciid[%d]: %s %d flags=%02x\n", i, parms->pciids[i].id, parms->pciids[i].mtu, parms->pciids[i].flags );
+		fprintf( stderr, "\t\thw_strip_crc=%d\n",  parms->pciids[i].hw_strip_crc );
         for( j = 0; j < parms->pciids[i].ntcs; j++ ) {
             if( (tcp = parms->pciids[i].tcs[j]) != NULL ) {				// traffic class defined for this priority
                 fprintf( stderr, "\t\ttclasses[%d]: %s, flags=%02x, max_bw: %d, min_bw: %d\n", j, tcp->hr_name, tcp->flags, tcp->max_bw, tcp->min_bw );

--- a/src/lib/parm_file_test.cfg
+++ b/src/lib/parm_file_test.cfg
@@ -15,7 +15,8 @@
 
     "pciids": [ 
                 {   "id": "0000:08:00.0",
-                    "mtu": 9000,
+                    "mtu": 9002,
+					"hw_strip_crc": true,
                     "enable_loopback": false,
                     "pf_driver": "pci-stub",
                     "vf_driver": "pci-stub",
@@ -71,7 +72,7 @@
                 },
 
                 {   "id": "0000:08:00.1",
-                    "mtu": 9000,
+                    "mtu": 9004,
                     "enable_loopback": false,
                     "pf_driver": "pci-stub",
                     "vf_driver": "pci-stub",
@@ -118,7 +119,7 @@
                 },
 
                 {   "id": "0000:08:00.2",
-                    "mtu": 9000,
+                    "mtu": 9006,
                     "enable_loopback": false,
                     "pf_driver": "pci-stub",
                     "vf_driver": "pci-stub",
@@ -214,7 +215,8 @@
                 {   
 					"rem-pc4": "test without any traffic classes",
 					"id": "0000:08:00.3",
-                    "mtu": 9000,
+                    "mtu": 9008,
+					"hw_strip_crc": false,
                     "enable_loopback": false,
                     "pf_driver": "pci-stub",
                     "vf_driver": "pci-stub",

--- a/src/lib/vfdlib.h
+++ b/src/lib/vfdlib.h
@@ -11,6 +11,11 @@
 	Things that need to be visible to vfd
 */
 
+// ----- jw_xapi --------------------------
+#define JWFMT_HEX		1
+#define JWFMT_INT		2
+#define JWFMT_FLOAT		3
+
 //----------------- config.c --------------------------------------------------------------------------
                                     // tc_class_t struct flags
 #define TCF_LOW_LATENCY 0x01
@@ -51,6 +56,7 @@ typedef struct {
 typedef struct {
 	char*	id;
 	int		mtu;
+	int		hw_strip_crc;			// set hardware to strip crc when true
 	unsigned int flags;				// PFF_ flag constants
 									// QoS members
     int32_t ntcs;					// number of TCs (4 or 8)
@@ -180,4 +186,12 @@ extern char* jw_string_ele( void* st, const char* name, int idx );
 extern float jw_value_ele( void* st, const char* name, int idx );
 extern void* jw_obj_ele( void* st, const char* name, int idx );
 extern int jw_array_len( void* st, const char* name );
+
+// ---------------- jw_xapi ---------------------------------------------------------------------------------
+extern int get_bool( void* jblob, char const* field_name, int def_value );
+extern float get_value( void* jblob, char const* field_name, float def_value );
+extern int get_ivalue( void* jblob, char const* field_name, int def_value );
+extern char* get_value_as_str( void* jblob, char const* field_name, char const* def_value, int  fmt );
+extern char* get_str( void* jblob, char const* field_name, char const* def_value );
+
 #endif

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -50,7 +50,8 @@
 				31 Jan 2017 - ensure that the *cast settings are restored after vlan and vlanmac callbacks.
 				11 Feb 2017 - Set drop enable bit on VF's queues only between reset and queue ready. Setting
 							on constantly causes packet loss on the NIC.  Change the hardware CRC strip
-							setting to true.
+							setting to true. Add ability to turn off hardware crc stripping via the main
+							parm file.
 */
 
 
@@ -1286,7 +1287,7 @@ main(int argc, char **argv)
 					//state = dcb_port_init(portid, mbuf_pool);
 					state = dcb_port_init( &running_config->ports[pfidx], mbuf_pool );
 				} else {
-					state = port_init(portid, mbuf_pool);
+					state = port_init(portid, mbuf_pool, g_parms->pciids[portid].hw_strip_crc );
 				}
 
 				if( state != 0 ) {

--- a/src/vfd/qos.c
+++ b/src/vfd/qos.c
@@ -639,7 +639,11 @@ extern int enable_dcb_qos( sriov_port_t *port, int* pctgs, int tc8_mode, int opt
 	qos_set_mrqc( pf, tc8_mode );				// set mult rec/tx queue control
 	qos_set_mtqc( pf, tc8_mode );
 	qos_set_vtctl( pf );
-	set_queue_drop( pf, 1 );					// enable queue dropping for all
+
+	// do NOT invoke set_queue_drop(); drop enable bit is set by callback when needed
+	
+	disable_default_pool( pf );					// prevent unknown packets from being placed on default queue
+
 	/*
 	DEPRECATED == this is handled by set_queue_drop
 	for( i = 0; i < 32; i ++ ) {

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -383,7 +383,7 @@ int vf_stats_display(uint8_t port_id, uint32_t pf_ari, int vf, char * buff, int 
 int port_xstats_display(uint8_t port_id, char * buff, int bsize);
 int dump_vlvf_entry(portid_t port_id);
 
-int port_init(uint8_t port, struct rte_mempool *mbuf_pool);
+int port_init(uint8_t port, struct rte_mempool *mbuf_pool, int hw_strip_crc );
 void tx_set_loopback(portid_t port_id, u_int8_t on);
 
 void ether_aton_r(const char *asc, struct ether_addr * addr);

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -74,6 +74,9 @@
 #include <vfdlib.h>
 
 // ---------------------------------------------------------------------------------------
+#define SET_ON				1		// on/off parm constants
+#define SET_OFF				0
+
 #define VF_VAL_MCAST		0		// constants passed to get_vf_value()
 #define VF_VAL_BCAST		1
 #define VF_VAL_MSPOOF		2
@@ -152,7 +155,7 @@ static const struct rte_eth_conf port_conf_default = {
 		.hw_vlan_filter = 0, /**< VLAN filtering disabled */
 		.hw_vlan_strip  = 0, /**< VLAN strip enabled. */
 		.hw_vlan_extend = 0, /**< Extended VLAN disabled. */
-		.hw_strip_crc   = 0, /**< CRC stripped by hardware */
+		.hw_strip_crc   = 1, /**< CRC stripped by hardware */
 		},
 	.intr_conf = {
 		.lsc = ENABLED, 		// < lsc interrupt feature enabled
@@ -418,6 +421,9 @@ int vfd_update_nic( parms_t* parms, sriov_conf_t* conf );
 int vfd_init_fifo( parms_t* parms );
 int is_valid_mac_str( char* mac );
 char*  gen_stats( sriov_conf_t* conf, int pf_only, int pf );
+
+//------- queue support -------------------------
+void set_pfrx_drop(portid_t port_id, int state );
 
 // --- tools --------------------------------------------
 extern int stricmp(const char *s1, const char *s2);


### PR DESCRIPTION
The setting of the drop enable bit was changed to prevent the NIC from losing packets. 
The setting of the hardware strip crc value now defaults to true and may be configured in the main parm file for each PF. 