### PR TITLE
Cap MTU, fix copyright, support multiple VLANs with strip

### DIFF
--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -190,7 +190,7 @@ extern parms_t* read_parms( char* fname ) {
 		}
 
 		if( jw_missing( jblob, "default_mtu" ) ) {			// could be an old install using deprecated mtu, so look for that and default if neither is there
-			def_mtu = jw_missing( jblob, "mtu" ) ? 9000 : (int) jw_value( jblob, "mtu" );
+			def_mtu = jw_missing( jblob, "mtu" ) ? 9420 : (int) jw_value( jblob, "mtu" );
 		} else {
  		 	def_mtu = (int) jw_value( jblob, "default_mtu" );
 		}
@@ -337,6 +337,10 @@ extern parms_t* read_parms( char* fname ) {
 								}
 							}
 						}
+					}
+
+					if(  parms->pciids[i].mtu > 9420 ) {
+						 parms->pciids[i].mtu = 9420;		// niantic has issues with packets > 9.5K when loopback is enabled, so cap here
 					}
 				}
 			} else {

--- a/src/package/vfd_debian/copyright
+++ b/src/package/vfd_debian/copyright
@@ -1,2 +1,15 @@
-(C) 2016 AT&T
-Internal Use Only
+ ---------------------------------------------------------------------------
+   Copyright (c) 2016 AT&T Intellectual Property
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at:
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ ---------------------------------------------------------------------------

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -52,6 +52,7 @@
 							on constantly causes packet loss on the NIC.  Change the hardware CRC strip
 							setting to true. Add ability to turn off hardware crc stripping via the main
 							parm file.
+				23 Feb 2017 - Allow multiple VLAN IDs with strip == true.
 */
 
 
@@ -642,11 +643,16 @@ cmp_vfs (const void * a, const void * b)
 }
 
 /*
-	Set up the insert and strip charastics on the NIC. The interface should ensure that
-	the right parameter combinations are set and reject an add request if not, but
-	we are a bit parinoid and will help to enforce things here too.  If one VLAN is in
-	the list, then we allow strip_stag to control what we do. If multiple VLANs are in
-	the list, then we don't strip nor insert.
+	2017/03/23 - We now allow strip/insert when there are multiple VLAN IDs:
+		If strip == true and one ID is supplied, that ID will stripped on Rx and 
+		inserted on Tx.
+
+		If strip == true and more than one ID supplied, the outer (s) tag will be
+		stripped on Rx, and the ID from the packet descriptor will be inserted on Tx.
+	
+		IF strip == false, no stripping will take place, and insertion will be based
+		on the packet descriptor if it exists (this is default behavour when insert
+		setting is clear).
 
 	Returns 0 on failure; 1 on success.
 */
@@ -668,9 +674,9 @@ static int vfd_set_ins_strip( struct sriov_port_s *port, struct vf_s *vf ) {
 			tx_vlan_insert_set_on_vf( port->rte_port_number, vf->num, 0 );					// no strip, so no insert
 		}
 	} else {
-		bleat_printf( 2, "%s vf: %d vlan list contains %d entries; strip/insert turned off", port->name, vf->num, vf->num_vlans );
-		rx_vlan_strip_set_on_vf(port->rte_port_number, vf->num, 0 );					// if more than one vlan in the list force strip to be off
-		tx_vlan_insert_set_on_vf( port->rte_port_number, vf->num, 0 );					// and set insert to id 0
+		bleat_printf( 2, "%s vf: %d vlan list contains %d entries; strip set to %d; insert turned off", port->name, vf->num, vf->num_vlans, vf->strip_stag );
+		rx_vlan_strip_set_on_vf( port->rte_port_number, vf->num, vf->strip_stag );		// strip is variable
+		tx_vlan_insert_set_on_vf( port->rte_port_number, vf->num, 0 );					// but insert must always be clear so that packet descriptor is used
 	}
 
 	return 1;

--- a/src/vfd/vfd_rif.c
+++ b/src/vfd/vfd_rif.c
@@ -12,6 +12,7 @@
 				30 Jan 2017 : Fix vfid check to detect pars error.
 				14 Feb 2017 : Correct bug in del range check on vf number.
 				21 Feb 2017 : Prevent empty vlan id list from being accepted.
+				23 Mar 2017 : Allow multiple VLAN IDs when strip == true.
 */
 
 
@@ -461,6 +462,10 @@ extern int vfd_add_vf( sriov_conf_t* conf, char* fname, char** reason ) {
 		return 0;
 	}
 
+	/*
+	We now allow multiple VLAN IDs when stripping.  Strip is set (1) and insert is cleared (0) which 
+	causes strip on Rx and the tag indicated in the packet descriptor to be inserted on Tx.
+
 	if( vfc->strip_stag  &&  vfc->nvlans > 1 ) {		// one vlan is allowed when stripping
 		snprintf( mbuf, sizeof( mbuf ), "conflicting options: strip_stag may not be supplied with a list of vlan ids" );
 		bleat_printf( 1, "vf not added: %s", mbuf );
@@ -470,6 +475,7 @@ extern int vfd_add_vf( sriov_conf_t* conf, char* fname, char** reason ) {
 		free_config( vfc );
 		return 0;
 	}
+	*/
 
 	if( vfc->nvlans <= 0 ) {							// must have at least one VLAN defined or bad things happen on the NIC
 		snprintf( mbuf, sizeof( mbuf ), "vlan id list may not be empty" );


### PR DESCRIPTION
Three commits:
- fix copyright in the package directory that implied 'internal use only'; not removed when a skeleton directory was used to seed the package directory.

- allow multiple VLAN IDs to be supplied when stripping is set to true

- Set the max allowable MTU from the config to 9.2K; slightly larger than what seems standard jumbo-gram size. 