### PR TITLE
Per AT&T call, enable MAC address change enforcment.

### DIFF
--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -1127,7 +1127,6 @@ lsi_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param)
 	the message type.
 */
 #ifdef BNXT_SUPPORT
-#if 0
 static bool verify_mac_address(uint8_t port_id, uint16_t vf, void *mac)
 {
 	struct vf_s *vf_cfg = suss_vf(port_id, vf);
@@ -1149,7 +1148,6 @@ static bool verify_mac_address(uint8_t port_id, uint16_t vf, void *mac)
 
 	return false;
 }
-#endif
 
 void
 bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param)
@@ -1165,7 +1163,6 @@ bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *
 	switch (mbox_type) {
 		/* Allow and trigger a refresh */
 		case HWRM_FUNC_VF_CFG:
-#if 0
 		{
 			struct hwrm_func_vf_cfg_input *vcfg = p->msg;
 
@@ -1181,9 +1178,7 @@ bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *
 			add_refresh = true;
 			break;
 		}
-#endif
 		case HWRM_CFA_L2_FILTER_ALLOC:
-#if 0
 		{
 			struct hwrm_cfa_l2_filter_alloc_input *l2a = p->msg;
 
@@ -1194,7 +1189,6 @@ bnxt_vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *
 			add_refresh = true;
 			break;
 		}
-#endif
 
 		case HWRM_VNIC_CFG:
 		case HWRM_FUNC_RESET:


### PR DESCRIPTION
Allowing VFs to change MAC is a side-effect of Intel requirement to
enable MAC anti-spoof whenever VLAN anti-spoof is enabled.  Since
Broadcom doesn't have this limiation, the expectation is that MAC
anti-spoof will be disabled and VLAN anti-spoof will be enabled.