### PR TITLE
Make flow control dpdk based

### DIFF
--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -189,6 +189,12 @@ extern parms_t* read_parms( char* fname ) {
 			}
 		}
 
+		if( jw_is_bool( jblob, "enable_flowcontrol" ) ) {
+			if( jw_value( jblob, "enable_flowcontrol" ) ) {
+				parms->rflags |= RF_ENABLE_FC;
+			}
+		}
+
 		if( jw_missing( jblob, "default_mtu" ) ) {			// could be an old install using deprecated mtu, so look for that and default if neither is there
 			def_mtu = jw_missing( jblob, "mtu" ) ? 9420 : (int) jw_value( jblob, "mtu" );
 		} else {

--- a/src/lib/vfdlib.h
+++ b/src/lib/vfdlib.h
@@ -28,7 +28,7 @@
 									// flags set in parm struct related to running state
 #define RF_ENABLE_QOS	0x01		// enable qos
 #define RF_INITIALISED	0x02		// init has finished
-#define RF_OVERRIDE_FC	0x04		// override flow control in non-qos mode is enabled
+#define RF_ENABLE_FC	0x04		// enable flow control for all PFs
 
 #define MAX_TCS			8			// max number of traffic classes supported (0 - 7)
 #define NUM_BWGS		8			// number of bandwidth groups

--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -967,43 +967,48 @@ port_init(uint8_t port, __attribute__((__unused__)) struct rte_mempool *mbuf_poo
 }
 
 /*
-	EXPERIMANTAL --
-	Set the flow control config when not in qos.
+	Set flow control on.  We normally require switches to disable flow control on ports 
+	connected to VFd managed PFs, however if this cannot be controlled this provides the
+	means to enable it.  
 
-	Force should be set when calling during initialisation and not running in qos mode.
-	It causes us to track that we are allowed to reset the flag if called without
-	force on renegotiate callbacks.
+	Force should be used during initialisation. It causes the allow flag to be set and enables 
+	the callback processing function(s) to call blindly; the flow control will be set only if 
+	it was enabled during initialisation and doesn't require the callback function(s) to access 
+	the running parameters.
+
+	This function _only_ sets the flow control enable flag and does _not_ change the 
+	high/low thresholds or any timing values on the NIC.
 */
-extern void set_fcc( portid_t pf, int force ) {
-	static int allowed = 0;			// allows to safely call for reset
-
-	uint32_t val;
-	uint32_t cval = 0;				// current value read from nic
-	uint32_t offset;
-	uint32_t mask;
+extern void set_fc_on( portid_t pf, int force ) {
+	static int allowed = 0;	
+	struct rte_eth_fc_conf fcstate;		// current flow control settings
+	int		show = 0;					// show pf details; only during initialisation
+	int		state = 0;
 
 	if( force ) {
+bleat_printf( 0, ">>>>>  forcing flow control to be on" );
 		allowed = 1;
+		show = 1;
 	} else {
 		if( ! allowed ) {
 			return;
 		}
 	}
 
-	offset = 0x03d00;		// FCCFG.TFCE=10b
-	mask = 0xffffffe7;
-	cval = port_pci_reg_read( pf, offset );
-	val = 1 << 3;												// 01b (bits 3,4)  flow control on when not in dcb (match ixgbe driver)
-	port_pci_reg_write( pf, offset, (cval & mask) | val );		// flip on our bits, and set
-	bleat_printf( 1, "tfce %08x & %08x | %08x = %08x", cval, mask, val, (cval & mask) | val );
+	if( (state = rte_eth_dev_flow_ctrl_get( pf, &fcstate )) < 0 ) {		// get current settings; we'll keep high/low thresolds the same
+		if( show ) {
+			bleat_printf( 0, "WRN: flow control for pf %d cannot be set: %d (%s)", pf, state, strerror( -state ) );
+		}
+		return;													// either invalid pf or not supported; either way get out
+	}
 
-	// priority flow control enable should be set only when in dcb mode
-	offset = 0x04294;    	// MFLCN.RPFCE=1b RFCE=0b
-	val = 0x0a;				// match the ixgbe driver setting
-	mask =0xfffffff0;
-	cval = port_pci_reg_read( pf, offset );
-	port_pci_reg_write( pf, offset, (cval & mask) | val );		// flip on our bits, and set
-	bleat_printf( 1, "mflcn %08x & %08x | %08x = %08x", cval, mask, val, (cval & mask) | val );
+	if( show ) {												// only dump states during initialisation
+		bleat_printf( 1, "flow control state: pf=%d high=%d low=%d pause=%d send_x=%d mode=%d autoneg=%d", 
+				(int) pf, (int) fcstate.high_water, (int) fcstate.low_water, (int) fcstate.pause_time, (int) fcstate.send_xon, (int) fcstate.mode, (int) fcstate.autoneg );
+	}
+
+	fcstate.mode = RTE_FC_FULL;									// enable both Tx and Rx
+	rte_eth_dev_flow_ctrl_set( pf, &fcstate );
 }
 
 
@@ -1126,7 +1131,7 @@ vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param
 			}
 
 			restore_vf_setings(port_id, vf);
-			set_fcc( port_id, 0 );									// reset flow-control if allowed
+			set_fc_on( port_id, !FORCE );									// enable flow control if allowed (force off)
 			tx_set_loopback( port_id, suss_loopback( port_id ) );		// enable loopback if set (could be reset if link was down)
 			add_refresh_queue( port_id, vf );		// schedule a complete refresh when the queue goes hot
 			break;
@@ -1145,7 +1150,7 @@ vf_msb_event_callback(uint8_t port_id, enum rte_eth_event_type type, void *param
 			p->retval =  RTE_PMD_IXGBE_MB_EVENT_PROCEED;   /* do what's needed */
 			bleat_printf( 3, "Type: %d, Port: %d, VF: %d, OUT: %d, _T: %s ", type, port_id, vf, p->retval, "IXGBE_VF_API_NEGOTIATE");
 			
-			set_fcc( port_id, 0 );									// reset flow-control if allowed
+			set_fc_on( port_id, !FORCE );									// enable flow control if allowed
 			restore_vf_setings(port_id, vf);							// these must happen now, do NOT queue it. if not immediate guest-guest may hang
 			tx_set_loopback( port_id, suss_loopback( port_id ) );		// enable loopback if set (could be reset if link goes down)
 			break;

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -12,6 +12,7 @@
 					rather than to have them scattered.
 				22 Mar 2017 - Set the jumbo frame flag in the default dev config.
 					Fix comment in same initialisation.
+				16 May 2017 - Add flow control flag constant.
 */
 
 #ifndef _SRIOV_H_
@@ -78,6 +79,7 @@
 // ---------------------------------------------------------------------------------------
 #define SET_ON				1		// on/off parm constants
 #define SET_OFF				0
+#define FORCE				1
 
 #define VF_VAL_MCAST		0		// constants passed to get_vf_value()
 #define VF_VAL_BCAST		1
@@ -143,7 +145,8 @@ typedef uint16_t streamid_t;
 #define DISABLED	0
 								// port flags
 #define PF_LOOPBACK	0x01		// loopback is enabled
-#define PF_OVERSUB	0x02
+#define PF_OVERSUB	0x02		// allow qos oversubscription
+#define PF_FC_ON	0x04		// turn flow control on for port
 
 /*
 	Provides a static port configuration struct with defaults.
@@ -426,7 +429,7 @@ int is_valid_mac_str( char* mac );
 char*  gen_stats( sriov_conf_t* conf, int pf_only, int pf );
 
 //-- testing --
-extern void set_fcc( portid_t pf, int force );
+extern void set_fc_on( portid_t pf, int force );
 extern void set_fd_off( portid_t port_id );
 extern void set_rx_pbsize( portid_t port_id );
 


### PR DESCRIPTION
The initial setting of flow control was specific to Niantic NICs. These changes use the dpdk library to set flow control, and allow it to be set from the config file or the command line. 