### PR TITLE
Nic agnostic

### DIFF
--- a/src/lib/config.c
+++ b/src/lib/config.c
@@ -16,6 +16,7 @@
 				11 Feb 2017 : Fix issues with leading spaces rather than tabs (formatting)
 				26 May 2017 : Allow promisc to be set (default is true to match original behavour)
 				08 Jun 2017 : Allow huge_pages to be set (defult is on)
+				10 Jul 2017 : We now support "mac": "addr" rather than an array.
 
 	TODO:		convert things to the new jw_xapi functions to make for easier to read code.
 */
@@ -511,8 +512,14 @@ extern vf_config_t*	read_config( char* fname ) {
 				// TODO -- how to handle error? free and return nil?
 			}
 		} else {
-			vfc->nmacs = 0;		// if not set len() might return -1
-			vfc->macs = NULL;	// take no chances
+			if(  (stuff = jw_string( jblob, "mac" )) ) {							// new, going forward, just one MAC
+				vfc->nmacs = 1;
+				vfc->macs = malloc( sizeof( *vfc->macs ) * 1 );						// VFd should always support an array 
+				vfc->macs[0] = ltrim( stuff );
+			} else {
+				vfc->nmacs = 0;		// if not set len() might return -1
+				vfc->macs = NULL;	// take no chances
+			}
 		}
 
 		// ---- pick up the qos parameters --------------------------

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -871,7 +871,8 @@ extern int vfd_update_nic( parms_t* parms, sriov_conf_t* conf ) {
 							set_vf_rx_mac(port->rte_port_number, mac, vf->num, SET_OFF );
 					}
 				} else {
-					for( m = vf->first_mac; m <= vf->num_macs; ++m ) {			// if guest pushed a default, first will be [0], else first is [1]
+					//for( m = vf->first_mac; m <= vf->num_macs; ++m ) {			// if guest pushed a default, first will be [0], else first is [1]
+					for( m = vf->num_macs - 1; m >= vf->first_mac; m-- ) {			// must run in reverse order because of FV oddness
 						mac = vf->macs[m];
 						bleat_printf( 2, "adding mac [%d]: port: %d vf: %d mac: %s", m, port->rte_port_number, vf->num, mac );
 
@@ -1274,7 +1275,7 @@ main(int argc, char **argv)
 		case 'h':
 		case '?':
 			printf( "\nVFd %s %s\n", vnum, version );
-			printf( "(17608)\n" );
+			printf( "(17710)\n" );
 			printf("%s\n", main_help);
 			exit( 0 );
 			break;

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -872,7 +872,8 @@ extern int vfd_update_nic( parms_t* parms, sriov_conf_t* conf ) {
 					}
 				} else {
 					//for( m = vf->first_mac; m <= vf->num_macs; ++m ) {			// if guest pushed a default, first will be [0], else first is [1]
-					for( m = vf->num_macs - 1; m >= vf->first_mac; m-- ) {			// must run in reverse order because of FV oddness
+					bleat_printf( 2, "configuring %d mac addresses: port: %d vf: %d firstmac=%d", vf->num_macs, port->rte_port_number, vf->num, vf->first_mac );
+					for( m = vf->num_macs; m >= vf->first_mac; m-- ) {				// must run in reverse order because of FV oddness
 						mac = vf->macs[m];
 						bleat_printf( 2, "adding mac [%d]: port: %d vf: %d mac: %s", m, port->rte_port_number, vf->num, mac );
 

--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -772,6 +772,36 @@ void set_queue_drop( portid_t port_id, int state ) {
 	disable_default_pool(port_id);
 }
 
+/*
+	Different NICs may have different reuirements for antispoofing.  We always force VLAN antispoofing
+	to be on, which meanst that normally MAC antispoofing can be off.  However, on the niantic if one
+	is on, they both must be on, so this function exists to return the proper mac antispoofing value
+	(true or false) based on the port.
+*/
+int get_mac_antispoof( portid_t port_id )
+{
+  int sv = 0;				// spoof value: default to setting to off (allow guests to use any mac)
+
+	uint dev_type = get_nic_type(port_id);
+	switch (dev_type) {
+		case VFD_NIANTIC:
+			sv = 1;
+			bleat_printf( 0, "forcing mac antispoofing to be on for niantic" );
+			break;
+			
+		case VFD_FVL25:		
+			break;
+
+		case VFD_BNXT:
+			break;
+			
+		default:
+			break;	
+	}
+
+	return sv;
+}
+
 // --------------- pending reset support ----------------------------------------------------------------------
 /*
 	The refresh queue is where VFd manages queued reset requests. When we receive

--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -447,6 +447,7 @@ int vfd_init_fifo( parms_t* parms );
 int is_valid_mac_str( char* mac );
 char*  gen_stats( sriov_conf_t* conf, int pf_only, int pf );
 int get_nic_type(portid_t port_id);
+int get_mac_antispoof( portid_t port_id );
 int get_max_qpp( uint32_t port_id );
 int get_num_vfs( uint32_t port_id );
 

--- a/src/vfd/vfd_bnxt.c
+++ b/src/vfd/vfd_bnxt.c
@@ -94,18 +94,41 @@ vfd_bnxt_set_vf_multicast_promisc(uint8_t port_id, uint16_t vf_id, uint8_t on)
 }
 
 
+/*
+	This adds a MAC address to the Rx whitelist.  See vfd_bnxt_set_vf_default_mac_addr() 
+	for adding a MAC as the default (guest visible) MAC address.
+*/
 int 
 vfd_bnxt_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr)
 {
-	int diag = rte_pmd_bnxt_set_vf_mac_addr(port_id, vf_id, mac_addr);
+	int diag = rte_pmd_bnxt_mac_addr_add(port_id, mac_addr, vf_id );
 	if (diag < 0) {
 		bleat_printf( 0, "rte_pmd_bnxt_set_vf_mac_addr failed: port_pi=%d, vf_id=%d) failed rc=%d", port_id, vf_id, diag );
 	} else {
 		bleat_printf( 3, "rte_pmd_bnxt_set_vf_mac_addr successful: port_id=%d, vf=%d", port_id, vf_id);
 	}
+
+	return diag;
+}
+
+/*
+	Set the default rx MAC address for the pf/vf. This is the address that will be visible into the guest.
+*/
+int vfd_bnxt_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr ) {
+	int diag;
+
+	diag  = rte_pmd_bnxt_set_vf_mac_addr(port_id, vf_id, mac_addr);
+
+	if (diag < 0) {
+		bleat_printf( 0, "rte_pmd_bnxt_set_vf_default_mac_addr failed: port_pi=%d, vf_id=%d) failed rc=%d", port_id, vf_id, diag );
+	} else {
+		bleat_printf( 3, "rte_pmd_bnxt_set_vf_default_mac_addr successful: port_id=%d, vf=%d", port_id, vf_id);
+	}
 	
 	return diag;
 }
+
+
 
 
 int 

--- a/src/vfd/vfd_bnxt.h
+++ b/src/vfd/vfd_bnxt.h
@@ -18,6 +18,7 @@ int vfd_bnxt_set_tx_loopback(uint8_t port, uint8_t on);
 int vfd_bnxt_set_vf_unicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
 int vfd_bnxt_set_vf_multicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
 int vfd_bnxt_set_vf_mac_addr(uint8_t port, uint16_t vf_id, struct ether_addr *mac_addr);
+int vfd_bnxt_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf_id, struct ether_addr *mac_addr );
 int vfd_bnxt_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
 int vfd_bnxt_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
 int vfd_bnxt_set_vf_broadcast(uint8_t port, uint16_t vf_id, uint8_t on);

--- a/src/vfd/vfd_ixgbe.c
+++ b/src/vfd/vfd_ixgbe.c
@@ -115,6 +115,24 @@ vfd_ixgbe_set_vf_mac_addr(uint8_t port_id, uint16_t vf_id, struct ether_addr *ma
 	return diag;
 }
 
+/*
+	Set the 'default' MAC address for the VF. This is different than the set_vf_rx_mac() funciton
+	inasmuch as the address should be what the driver reports to a DPDK application when the 
+	MAC address is 'read' from the device.
+*/
+int vfd_ixgbe_set_vf_default_mac_addr( portid_t port_id, uint16_t vf, struct ether_addr *mac_addr ) {
+	int state;
+
+	state =  rte_pmd_ixgbe_set_vf_mac_addr( port_id, vf, mac_addr );
+	if( state < 0 ) {
+		bleat_printf( 0, "rte_pmd_ixgbe_set_vf_default_mac_addr failed: (port_id=%d, vf_id=%d) failed rc=%d", port_id, vf, state );
+	} else {
+		bleat_printf( 3, "rte_pmd_ixgbe_set_vf_default_mac_addr successful: port_id=%d, vf_id=%d", port_id, vf );
+	}
+
+	return state;
+}
+
 
 int 
 vfd_ixgbe_set_vf_vlan_stripq(uint8_t port_id, uint16_t vf_id, uint8_t on)

--- a/src/vfd/vfd_ixgbe.h
+++ b/src/vfd/vfd_ixgbe.h
@@ -16,6 +16,7 @@ int vfd_ixgbe_set_tx_loopback(uint8_t port, uint8_t on);
 int vfd_ixgbe_set_vf_unicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
 int vfd_ixgbe_set_vf_multicast_promisc(uint8_t port, uint16_t vf_id, uint8_t on);
 int vfd_ixgbe_set_vf_mac_addr(uint8_t port, uint16_t vf_id, struct ether_addr *mac_addr);
+int vfd_ixgbe_set_vf_default_mac_addr( uint8_t port_id, uint16_t vf, struct ether_addr *mac_addr );
 int vfd_ixgbe_set_vf_vlan_stripq(uint8_t port, uint16_t vf, uint8_t on);
 int vfd_ixgbe_set_vf_vlan_insert(uint8_t port, uint16_t vf_id, uint16_t vlan_id);
 int vfd_ixgbe_set_vf_broadcast(uint8_t port, uint16_t vf_id, uint8_t on);

--- a/src/vfd/vfd_rif.c
+++ b/src/vfd/vfd_rif.c
@@ -625,7 +625,7 @@ extern int vfd_add_vf( sriov_conf_t* conf, char* fname, char** reason ) {
 
 	vf->allow_untagged = 0;					// for now these cannot be set by the config file data
 	vf->vlan_anti_spoof = 1;
-	vf->mac_anti_spoof = vfc->antispoof_mac;
+	vf->mac_anti_spoof = get_mac_antispoof( port->rte_port_number );		// value depends on the nic in some cases
 
 	vf->rate = vfc->rate;
 	


### PR DESCRIPTION
Add MAC setting to accomodate FV single function and use both BC functions
Add changes to support single mac as string in VF config
Force MAC antispoofing only for niantic; forced off for other NICs now