### PR TITLE
Do not write registers for bnxt.

### DIFF
--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -1134,6 +1134,11 @@ extern void set_fcc( portid_t pf, int force ) {
 	uint32_t offset;
 	uint32_t mask;
 
+#ifdef BNXT_SUPPORT
+	if (strcmp(rte_eth_devices[port_id].driver->pci_drv.driver.name, "net_bnxt") == 0) {
+		return;
+	}
+#endif
 	if( force ) {
 		allowed = 1;
 	} else {


### PR DESCRIPTION
This disables set_fcc() on Broadcom, since the implementation was
hardware specific.