### PR TITLE
Process pf queue

### DIFF
--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -788,8 +788,15 @@ extern int vfd_update_nic( parms_t* parms, sriov_conf_t* conf ) {
 					bleat_printf( 1, "enabling promiscuous mode for port %d", port->rte_port_number );
 					rte_eth_promiscuous_enable(port->rte_port_number);
 				}
+				else {
+					bleat_printf( 1, "disabling promiscuous mode for port %d", port->rte_port_number );
+					rte_eth_promiscuous_disable(port->rte_port_number);
+				}
 				
-				rte_eth_allmulticast_enable(port->rte_port_number);	
+				if (get_nic_type(port->rte_port_number) == VFD_BNXT)
+					rte_eth_allmulticast_disable(port->rte_port_number);
+				else
+					rte_eth_allmulticast_enable(port->rte_port_number);
 			
 				if (get_nic_type(port->rte_port_number) == VFD_NIANTIC) {
 					ret = rte_eth_dev_uc_all_hash_table_set(port->rte_port_number, on);
@@ -955,8 +962,15 @@ extern int vfd_update_nic( parms_t* parms, sriov_conf_t* conf ) {
 						bleat_printf( 1, "enabling promiscuous mode for port %d", port->rte_port_number );
 						rte_eth_promiscuous_enable(port->rte_port_number);
 					}
+					else {
+						bleat_printf( 1, "disabling promiscuous mode for port %d", port->rte_port_number );
+						rte_eth_promiscuous_disable(port->rte_port_number);
+					}
 					
-					rte_eth_allmulticast_enable(port->rte_port_number);
+					if (get_nic_type(port->rte_port_number) == VFD_BNXT)
+						rte_eth_allmulticast_disable(port->rte_port_number);
+					else
+						rte_eth_allmulticast_enable(port->rte_port_number);
 					
 					if (get_nic_type(port->rte_port_number) == VFD_NIANTIC) {
 						ret = rte_eth_dev_uc_all_hash_table_set(port->rte_port_number, on);

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -1569,8 +1569,8 @@ main(int argc, char **argv)
 				uint16_t idx;
 				for (idx = 0; idx < nb_pkts; idx++)
 					rte_pktmbuf_free(pkts_burst[idx]);
+				bleat_printf( 4, "Discarded %hu PF %d frames", nb_pkts, portid);
 			}
-			bleat_printf( 4, "Discarded %hu PF %d frames", nb_pkts, portid);
 		}
 
 	}		// end !terminated while

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -1569,7 +1569,7 @@ main(int argc, char **argv)
 				uint16_t idx;
 				for (idx = 0; idx < nb_pkts; idx++)
 					rte_pktmbuf_free(pkts_burst[idx]);
-				bleat_printf( 4, "Discarded %hu PF %d frames", nb_pkts, portid);
+				bleat_printf( 4, "Discarded %hu frames on PF %d", nb_pkts, portid);
 			}
 		}
 

--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -1430,11 +1430,9 @@ extern void set_fc_on( portid_t pf, int force ) {
 	if( force ) {
 		allowed = 1;
 		show = 1;
-	} else {
-		if( ! allowed ) {
-			return;
-		}
 	}
+	else
+		show = 1;
 
 	if( (state = rte_eth_dev_flow_ctrl_get( pf, &fcstate )) < 0 ) {		// get current settings; we'll keep high/low thresolds the same
 		if( show ) {
@@ -1448,7 +1446,10 @@ extern void set_fc_on( portid_t pf, int force ) {
 				(int) pf, (int) fcstate.high_water, (int) fcstate.low_water, (int) fcstate.pause_time, (int) fcstate.send_xon, (int) fcstate.mode, (int) fcstate.autoneg );
 	}
 
-	fcstate.mode = RTE_FC_FULL;									// enable both Tx and Rx
+	if (allowed)
+		fcstate.mode = RTE_FC_FULL;								// enable both Tx and Rx
+	else
+		fcstate.mode = RTE_FC_NONE;								// disable both Tx and Rx
 	rte_eth_dev_flow_ctrl_set( pf, &fcstate );
 }
 


### PR DESCRIPTION
Various modifications to prevent the PF RX queue from consuming chip resources.

1) For BNXT devices, disable all multicast on the PF rather than enable it.
2) When the promiscuous setting is false in the PF config, explicitly disable promiscuous mode.
3) Explicitly disable flow control when it is not enabled.
4) When there are pending RX packets on the PFs, receive and discard them during the idle loop.