### PR TITLE
Nic agnostic - bug fixes

### DIFF
--- a/src/vfd/sriov.c
+++ b/src/vfd/sriov.c
@@ -1234,6 +1234,7 @@ vf_stats_display(uint8_t port_id, uint32_t pf_ari, int ivf, char * buff, int bsi
 
 
 	struct rte_eth_stats stats;
+	memset( &stats, 0, sizeof( stats ) );			// not all NICs fill all data, so ensure we have 0s
 	uint dev_type = get_nic_type(port_id);
 	switch (dev_type) {
 		case VFD_NIANTIC:

--- a/src/vfd/vfd_rif.c
+++ b/src/vfd/vfd_rif.c
@@ -13,6 +13,7 @@
 				14 Feb 2017 : Correct bug in del range check on vf number.
 				21 Feb 2017 : Prevent empty vlan id list from being accepted.
 				23 Mar 2017 : Allow multiple VLAN IDs when strip == true.
+				22 Sep 2017 : Prevent hanging lock in add_ports if already called.
 */
 
 
@@ -240,8 +241,10 @@ extern void vfd_add_ports( parms_t* parms, sriov_conf_t* conf ) {
 	pfdef_t*	pfc;			// pointer to the config info for a port (pciid)
 
 	rte_spinlock_lock( &conf->update_lock );
-	if( called )
+	if( called ) {
+		rte_spinlock_unlock( &conf->update_lock );
 		return;
+	}
 	called = 1;
 	
 	for( i = 0; pidx < MAX_PORTS  && i < parms->npciids; i++, pidx++ ) {


### PR DESCRIPTION
Bug fixes which were causing invalid error counts to show for Niantic nic in show all output.

Reorganised the port init code, and fixed bugs there (main.c):
   -- code to set offset/stride was outside of the block that prevented updates to ports that
       are not in the VFd config (and thus should be untouched)
  -- code to get information to set offset/stride was commented out for both boradcom and niantic
  -- code to get information from Mellanox NIC was unguarded
  -- invalid indexes were being used to reference the port struct in the running config 

If add_ports was called more than once it would leave the spin lock in a locked state. (vfd_rif.c)
