### PR TITLE
added rte_eal_cleanup during VFd termination

### DIFF
--- a/doc/hackers/vfd_hackers.xfm
+++ b/doc/hackers/vfd_hackers.xfm
@@ -52,9 +52,9 @@ controlled:
 .bl &lic1
 .li VLAN and MAC filtering (inbound)
 .sp .3
-.li Stripping of VLAN ID (single) from inbound traffic
+.li Stripping of VLAN ID from inbound traffic
 .sp .3
-.li Addition of VLAN ID (single) to outbound traffic
+.li Addition of VLAN ID to outbound traffic
 .sp .3
 .li Enabling/disabling broadcast, multicast, unicast 
 .el

--- a/src/vfd/Makefile
+++ b/src/vfd/Makefile
@@ -54,6 +54,7 @@ SRCS-y := main.c sriov.c qos.c vfd_mac.c vfd_rif.c vfd_dcb.c vfd_i40e.c vfd_ixgb
 endif
 
 CFLAGS += $(WERROR_FLAGS) -I $(PWD)/../lib/ -I $(RTE_SDK) -DVFD_KERNEL=${VFD_KERNEL}
+CFLAGS += -DALLOW_EXPERIMENTAL_API
 
 #-lconfig
 

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -499,6 +499,12 @@ static void close_ports( void ) {
 		//bleat_printf( 2, "device closed and detached: %s", dev_name );
 	}
 
+#if RTE_VER_YEAR >= 18     
+        bleat_printf( 0, "cleaning up eal" );
+        if (rte_eal_cleanup())
+            bleat_printf( 0, "rte_eal_cleanup error" );
+#endif
+    
 	bleat_printf( 0, "close ports finished" );
 }
 


### PR DESCRIPTION
Based on DPDK 18.02 release notes:

During rte_eal_init() EAL allocates memory from hugepages to enable its core libraries to perform their tasks. The rte_eal_cleanup() function releases these resources, ensuring that no hugepage memory is leaked. It is expected that all DPDK applications call rte_eal_cleanup() before exiting. Not calling this function could result in leaking hugepages, leading to failure during initialization of secondary processes.