### PR TITLE
Mac list indexing fixes + cleanup

### DIFF
--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -1842,7 +1842,7 @@ main(int argc, char **argv)
 				port2config_map[portid] = -1;					// we must not allow an interrupt to map (we shouldn't get interrupts, but be parinoid)
 				bleat_printf( 0, "pf %d (%s) is NOT in vfd config file and was not initialised", portid, pciid );
 			}
-	  }
+		}
 		
 		bleat_printf( 2, "port initialisation complete" );
 

--- a/src/vfd/main.c
+++ b/src/vfd/main.c
@@ -79,6 +79,7 @@
 				10 Jan 2018 - mlx5: Add VF queue sharing per TC.
 				19 Feb 2018 - Add support to ensure config directories exist. (#263)
 				26 Mar 2018 - Send log to file unless log_dir == stderr; allow -f for container with log file.
+				18 Apr 2018 - Correct stop point when dumping mac addresses.
 */
 
 
@@ -1446,7 +1447,7 @@ dump_sriov_config( sriov_conf_t* sriov_config)
 					sriov_config->ports[i].vfs[y].min_rate,
 					sriov_config->ports[i].vfs[y].link,
 					sriov_config->ports[i].vfs[y].num_vlans,
-					sriov_config->ports[i].vfs[y].num_macs + (sriov_config->ports[i].vfs[y].first_mac ? 0 : 1),
+					sriov_config->ports[i].vfs[y].num_macs,
 					split_ctl,
 					sriov_config->ports[i].mirrors[y].target,
 					sriov_config->ports[i].mirrors[y].dir,
@@ -1459,7 +1460,7 @@ dump_sriov_config( sriov_conf_t* sriov_config)
 				}
 	
 				int z;
-				for (z = sriov_config->ports[i].vfs[y].first_mac; z <= sriov_config->ports[i].vfs[y].num_macs; z++) {
+				for (z = sriov_config->ports[i].vfs[y].first_mac; z < sriov_config->ports[i].vfs[y].num_macs + sriov_config->ports[i].vfs[y].first_mac; z++) {
 					bleat_printf( 2, "dump: pf/vf: %d/%d mac[%d] %s ", sriov_config->ports[i].rte_port_number, sriov_config->ports[i].vfs[y].num, z, sriov_config->ports[i].vfs[y].macs[z]);
 				}
 			} else {

--- a/src/vfd/vfd_mac.c
+++ b/src/vfd/vfd_mac.c
@@ -7,7 +7,7 @@
 	Author:		E. Scott Daniels
 	Date:		28 October 2017  (broken from main.c and added extensions.
 
-	Mods:
+	Mods:		18 Apr 2018 - Correct for issue 294
 */
 
 
@@ -358,6 +358,7 @@ extern int set_macs( int port, int vfid ) {
 	struct sriov_port_s* pf = NULL;
 	char*	mac;
 	int m;
+	int si;								// start index for reverse loop
 	
 	if( (pf = suss_port( port )) == NULL ) {
 		bleat_printf( 1, "setl_macs: port doesn't map: %d", port );
@@ -369,8 +370,10 @@ extern int set_macs( int port, int vfid ) {
 		return 0;
 	}
 
-	bleat_printf( 1, "configuring %d mac addresses on pf/vf=%d/%d firstmac=%d", vf->num_macs, port, vfid, vf->first_mac );
-	for( m = vf->num_macs; m >= vf->first_mac; m-- ) {
+	si = (vf->num_macs - 1) + vf->first_mac;				// starting index
+	bleat_printf( 1, "configuring %d mac addresses on pf/vf=%d/%d firstmac=%d nm=%d si=%d", vf->num_macs, port, vfid, vf->first_mac, vf->num_macs,  si );
+
+	for( m = si; m >= vf->first_mac; m-- ) {
 		mac = vf->macs[m];
 		bleat_printf( 2, "adding mac [%d]: port: %d vf: %d mac: %s", m, port, vfid, mac );
 
@@ -378,7 +381,6 @@ extern int set_macs( int port, int vfid ) {
 			set_vf_rx_mac( port, mac, vfid, SET_ON );	// set in whitelist
 		} else {
 			set_vf_default_mac( port, mac, vfid );		// first is set as default
-			bleat_printf( 2, "Setting default mac was succesfull");
 		}
 	}
 


### PR DESCRIPTION
There were a couple of places where the index into the mac table for a VF wasn't computed correctly. We use a 1 based offset unless the guest 'registers' a default which is placed into slot 0; makes getting the right start/stop index right a bit less straight forward (as evidenced by the bugs).  