### PR TITLE
Block VFD daemon on post-start stage

### DIFF
--- a/src/system/vfd.conf
+++ b/src/system/vfd.conf
@@ -1,6 +1,5 @@
 description "Service to configure virtual functions"
 
-start on (started networking)
 start on (starting nova-compute)
 stop on (stopped networking)
 
@@ -15,7 +14,8 @@ script
 end script
 
 post-start script
-    sleep 15
+    echo "[`date`] VFd iplex ping... ">> $VFD_UPSTART_LOG
+    timeout 240 iplex ping
     echo "[`date`] VFd started... ">> $VFD_UPSTART_LOG
 end script
 
@@ -39,7 +39,7 @@ pre-start script
         echo "[`date`] Failed to start daemon, /var/lib/vfd/config is missing" >> $VFD_UPSTART_LOG
         exit 0
     fi
-    
+
     if [ "$(grep nova /etc/passwd | cut -d: -f1)" = "nova" ]
     then
         chown -R nova:nova /var/lib/vfd/config


### PR DESCRIPTION
VFD must be started and initialized BEFORE nova-compute.
`iplex ping` is used in order to prevent nova-compute
from starting too early when VFD is still initializing its state.

Also, unused `start on` is deleted.