### PR TITLE
Update paramiko requirement to advance past versions with security isues

### DIFF
--- a/src/support/tests/requirements.txt
+++ b/src/support/tests/requirements.txt
@@ -5,7 +5,7 @@ cryptography==2.0.2
 enum34==1.1.6
 idna==2.5
 ipaddress==1.0.18
-paramiko==2.2.1
+paramiko==2.2.4
 pcapy==0.11.1
 py==1.4.33
 pyasn1==0.3.1


### PR DESCRIPTION
The security problem github keeps nattering on about is caused if we require paramiko < 2.2.4. This is just a test tool, so no real issue, but fixed anyway.