### PR TITLE
Adjust for jsmn changes

### DIFF
--- a/src/lib/Makefile
+++ b/src/lib/Makefile
@@ -5,7 +5,8 @@
 
 MKSHELL = ksh
 
-jsmn_lib = -L jsmn -ljsmn
+# jsmn no longer builds into a library
+jsmn_lib = 
 vfd_lib = -L . -lvfd
 
 cflags = -I jsmn -g

--- a/src/lib/jw_xapi.c
+++ b/src/lib/jw_xapi.c
@@ -11,6 +11,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define JSMN_STATIC 1		// jsmn no longer builds into a library; this pulls as static functions
 #include <jsmn.h>
 
 #include "vfdlib.h"

--- a/src/lib/jwrapper.c
+++ b/src/lib/jwrapper.c
@@ -16,6 +16,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+#define JSMN_STATIC 1		// jsmn no longer builds into a library; this pulls as static functions
 #include <jsmn.h>
 
 #include "vfdlib.h"

--- a/src/lib/jwrapper_test.ksh
+++ b/src/lib/jwrapper_test.ksh
@@ -49,12 +49,16 @@ echo $json >$json_file
 md5sum $output |read value junk
 if [[ $value != "8349f6f812a412e021dbb0948e8f375e" ]]	# didn't match what we expected
 then
+	echo "------ test output below -----"
 	cat $output
+	echo "------------------------------"
+	echo "value=$value expected=8349f6f812a412e021dbb0948e8f375e"
 	echo "[FAIL] output didn't match what was expected"
 	rm /tmp/PID$$.*
 	exit 1
 fi
 
+echo "[PASS]"
 rm /tmp/PID$$.*
 exit 0
 

--- a/src/lib/mkfile
+++ b/src/lib/mkfile
@@ -1,7 +1,8 @@
 # mk is better (see plan-9)
 MKSHELL = ksh
 
-jsmn_lib = -L jsmn -ljsmn
+# jsmn no longer builds into a library
+jsmn_lib = 
 cc = gcc
 cflags = -I jsmn -g
 

--- a/src/lib/test_all.ksh
+++ b/src/lib/test_all.ksh
@@ -247,7 +247,7 @@ log=${1:-all_tests.log}
 
 
 # tests that can be run directly with valgrind
-for x in id_mgr_test "vf_config_test vf_test.cfg" "parm_file_test parm_test.cfg" fifo_test
+for x in id_mgr_test "vf_config_test parm_file_test.cfg" "parm_file_test parm_test.cfg" fifo_test
 do
 	printf "running %-20s"  "${x%% *}"
 	printf "\n----- %s -----\n" "$x" >>$log 

--- a/src/vfd/Makefile
+++ b/src/vfd/Makefile
@@ -12,7 +12,9 @@
 #### change this if needed
 #libconf = /usr/lib/x86_64-linux-gnu/libconfig.a
 libvfd = $(PWD)/../lib/libvfd.a
-libjsmn = $(PWD)/../lib/jsmn/libjsmn.a
+
+# jsmn no longer builds into a library
+libjsmn = 
 headers = $(PWD)/../lib/vfdlib.h
 patch_dir = $(PWD)/../dpdk_patches
 


### PR DESCRIPTION
Jsmn no longer generates a library. These changes are needed to properly build the vfd library with jsmn code.