### PR TITLE
Correct bad ifdef referencing DPDK versions >= 19.02

### DIFF
--- a/src/vfd/sriov.h
+++ b/src/vfd/sriov.h
@@ -180,16 +180,11 @@ typedef uint16_t streamid_t;
 /*
 	Provides a static port configuration struct with defaults.
 */
-#if RTE_VER_YEAR >= 18   && RTE_VER_MONTH >= 8  
+#if RTE_VER_YEAR > 18 || (RTE_VER_YEAR >= 18   && RTE_VER_MONTH >= 8)
 static const struct rte_eth_conf port_conf_default = {
 	.rxmode = {
 	.max_rx_pkt_len = 9000,
-#if RTE_VER_YEAR >= 18   && RTE_VER_MONTH > 8  
 	.offloads = (DEV_RX_OFFLOAD_CHECKSUM | DEV_RX_OFFLOAD_VLAN_STRIP),
-#else
-	.offloads = (DEV_RX_OFFLOAD_CHECKSUM | DEV_RX_OFFLOAD_CRC_STRIP | DEV_RX_OFFLOAD_VLAN_STRIP),
-#endif
-
 	},
 	.txmode = {
 		//.hw_vlan_insert_pvid = 1,

--- a/src/vfd/vfd_dcb.h
+++ b/src/vfd/vfd_dcb.h
@@ -15,7 +15,7 @@
 */
 static const struct rte_eth_conf eth_dcb_default = {
 	.rxmode = {
-#if RTE_VER_YEAR >= 18   && RTE_VER_MONTH > 8  
+#if RTE_VER_YEAR > 18 || (RTE_VER_YEAR >= 18   && RTE_VER_MONTH > 8)
 		.offloads = (DEV_RX_OFFLOAD_CHECKSUM | DEV_RX_OFFLOAD_VLAN_STRIP),
 #else
 		.offloads = (DEV_RX_OFFLOAD_CHECKSUM | DEV_RX_OFFLOAD_CRC_STRIP | DEV_RX_OFFLOAD_VLAN_STRIP),


### PR DESCRIPTION
The if defs broke as soon as the year moved to 19.